### PR TITLE
Api rest/new experimental/dp/f002

### DIFF
--- a/bknd-nest-11/src/app.controller.spec.ts
+++ b/bknd-nest-11/src/app.controller.spec.ts
@@ -15,8 +15,8 @@ describe('AppController', () => {
   });
 
   describe('root', () => {
-    it('should return "Hello World!"', () => {
-      expect(appController.getHello()).toBe('Hello World!');
+    it('should return the correct status', () => {
+      expect(appController.getStatus()).toBe('Status OK');
     });
   });
 });

--- a/bknd-nest-11/src/main.ts
+++ b/bknd-nest-11/src/main.ts
@@ -15,7 +15,7 @@ async function bootstrap() {
   .addBearerAuth()
   .build();
   
-  const document = () => SwaggerModule.createDocument(app, config);
+  const document = SwaggerModule.createDocument(app, config);
   SwaggerModule.setup('swagger', app, document);
 
   await app.listen(process.env.PORT ?? 3000);

--- a/signals-angular-20/src/app/pages/new-experimental-apis/components/data-stream/data-stream.component.html
+++ b/signals-angular-20/src/app/pages/new-experimental-apis/components/data-stream/data-stream.component.html
@@ -1,4 +1,4 @@
-<ng-content>
+<ng-container>
     <div class="websocket-container">
         <header class="websocket-header">
             <h3>WebSocket Data Stream</h3>
@@ -90,4 +90,4 @@
             }
         </div>
     </div>
-</ng-content>
+</ng-container>

--- a/signals-angular-20/src/app/pages/new-experimental-apis/components/resource/resource.component.html
+++ b/signals-angular-20/src/app/pages/new-experimental-apis/components/resource/resource.component.html
@@ -1,4 +1,4 @@
-<ng-content>
+<ng-container>
     <h3>Usuario</h3>
     @if (userResource.isLoading()) {
         <p>Cargando usuario...</p>
@@ -26,4 +26,4 @@
         }
     </div>
     }
-</ng-content>
+</ng-container>

--- a/signals-angular-20/src/app/pages/signals-service/signals-service.component.html
+++ b/signals-angular-20/src/app/pages/signals-service/signals-service.component.html
@@ -1,4 +1,4 @@
-<ng-content>
+<ng-container>
     <header>
     <h1>Ejemplo de Angular 20: Signals + Manejo de estados</h1>
     <p>Consumir una API REST con manejo de estado reactivo.</p>
@@ -32,4 +32,4 @@
       </div>
     }
   </section>
-</ng-content>
+</ng-container>


### PR DESCRIPTION
This pull request includes updates to improve code correctness, simplify templates, and enhance maintainability. The key changes involve updating test cases, correcting a Swagger document initialization, and replacing `ng-content` with `ng-container` in Angular templates for better structural semantics.

### Backend updates:
* **Test case modification**: Updated the test in `AppController` to check the status returned by `getStatus()` instead of the greeting from `getHello()`. (`bknd-nest-11/src/app.controller.spec.ts`, [bknd-nest-11/src/app.controller.spec.tsL18-R19](diffhunk://#diff-279a4c2f6794463fe50461740e64b8c9d67be2dc8b096882c3b4664ff7e1a8ccL18-R19))
* **Swagger initialization fix**: Corrected the `document` initialization in `main.ts` to directly call `SwaggerModule.createDocument` instead of wrapping it in a function. (`bknd-nest-11/src/main.ts`, [bknd-nest-11/src/main.tsL18-R18](diffhunk://#diff-b2c480474768e2937d56e76e23659033bd6b1fd8f5bbe3ebba55dbb06514fb29L18-R18))

### Angular template improvements:
* **Structural directive update**: Replaced `<ng-content>` with `<ng-container>` in the following components for improved structural semantics:
  - `data-stream.component.html` (`signals-angular-20/src/app/pages/new-experimental-apis/components/data-stream/data-stream.component.html`, [[1]](diffhunk://#diff-9c1e51d1c9db0474a69679786e07c0cf016d6c092a187e913f342c78f5eab06eL1-R1) [[2]](diffhunk://#diff-9c1e51d1c9db0474a69679786e07c0cf016d6c092a187e913f342c78f5eab06eL93-R93)
  - `resource.component.html` (`signals-angular-20/src/app/pages/new-experimental-apis/components/resource/resource.component.html`, [[1]](diffhunk://#diff-f2602f48dde605b06629b0cf5bb999a15ab1ea52b07e2d77362c0477532c63c5L1-R1) [[2]](diffhunk://#diff-f2602f48dde605b06629b0cf5bb999a15ab1ea52b07e2d77362c0477532c63c5L29-R29)
  - `signals-service.component.html` (`signals-angular-20/src/app/pages/signals-service/signals-service.component.html`, [[1]](diffhunk://#diff-abf19360d13e3d6a9671f0a97cb9ba08eb285ca8e93925fd768ef608e1df9e62L1-R1) [[2]](diffhunk://#diff-abf19360d13e3d6a9671f0a97cb9ba08eb285ca8e93925fd768ef608e1df9e62L35-R35)